### PR TITLE
Add Functions and proposed changes

### DIFF
--- a/ZabbixPS/Private/New-ZBXRestBody.ps1
+++ b/ZabbixPS/Private/New-ZBXRestBody.ps1
@@ -1,0 +1,71 @@
+function New-ZBXRestBody
+{
+    <#
+    .SYNOPSIS
+
+    Returns the correct API body for a Zabbix API call.
+
+    .DESCRIPTION
+
+    Intended as an internal function for returning the body of an API call where the params may change
+
+    .PARAMETER Method
+
+    The Zabbix API method used in the call
+
+    .PARAMETER ApiVersion
+
+    Specifies the API Version being used
+
+    .PARAMETER Param
+
+    A hashtable of Zabbix specific filters for the specific method
+
+    .INPUTS
+
+    None, does not support pipeline.
+
+    .OUTPUTS
+
+    Hashtable. RestMethod Body.
+
+    .EXAMPLE
+
+    Dynamically generates the body for an API call.
+
+    New-ZBXRestBody -Method 'event.problem' -API $ApiVersion -Params $params
+
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $Method,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ApiVersion,
+
+        [Parameter(Mandatory)]
+        [hashtable]
+        $Params
+
+    )
+
+    process
+    {
+        #todo create some validation for the params
+        #to make sure they match the methods for the Zabbix API
+        $body = @{
+            method  = $Method
+            jsonrpc = $ApiVersion
+            id      = 1
+
+            params  = $Params
+        }
+
+        $body
+    }
+
+}

--- a/ZabbixPS/Public/Confirm-ZBXEvent.ps1
+++ b/ZabbixPS/Public/Confirm-ZBXEvent.ps1
@@ -114,18 +114,18 @@ function Confirm-ZBXEvent
         [Alias('action')]
         [ValidateSet('CloseProblem','Acknowledge','AddMessage','ChangeSeverity')]
         [string[]]
-        $Action,
+        $AcknowledgeAction,
 
         [Parameter()]
         [Alias('message')]
         [string]
-        $Message,
+        $AcknowledgeMessage,
 
         [Parameter()]
         [Alias('severity')]
         [ValidateSet('NotClassified','Information','Warning','Average','High','Disaster')]
         [string]
-        $Severity
+        $NewSeverity
     )
 
     begin
@@ -171,9 +171,11 @@ function Confirm-ZBXEvent
                 #uses the hardcoded Alias of the parameter as the API friendly param
                 $apiParam = $MyInvocation.MyCommand.Parameters[$Parameter.key].Aliases[0]
                 switch ($apiParam) {
-                    'action'   { foreach ($value in $parameter.Value) {
-                                    $apiValue += $ActionValues[$value]
+                    'action'   { [int]$total = 0
+                                 foreach ($value in $parameter.Value) {
+                                    $total = $total + [int]$ActionValues[$value]
                                  }
+                                 $apiValue = $total
                                  break
                                }
                     'severity' { $apiValue = $SeverityValues[$Parameter.Value]; break }

--- a/ZabbixPS/Public/Confirm-ZBXEvent.ps1
+++ b/ZabbixPS/Public/Confirm-ZBXEvent.ps1
@@ -1,0 +1,209 @@
+function Confirm-ZBXEvent
+{
+    <#
+    .SYNOPSIS
+
+    Changes the status of an Event
+
+    .DESCRIPTION
+
+    Changes the acknowledgement of an Event
+
+    .PARAMETER Uri
+
+    The Zabbix instance uri.
+
+    .PARAMETER Credential
+
+    Specifies a user account that has permission to the project.
+
+    .PARAMETER Proxy
+
+    Use a proxy server for the request, rather than connecting directly to the Internet resource. Enter the URI of a network proxy server.
+
+    .PARAMETER ProxyCredential
+
+    Specifie a user account that has permission to use the proxy server that is specified by the -Proxy parameter. The default is the current user.
+
+    .PARAMETER Session
+
+    ZabbixPS session, created by New-ZBXSession.
+
+    .PARAMETER EventId
+
+    IDs of the events to acknowledge.
+
+    .PARAMETER Action
+
+    Event update action(s). This is bitmask field (under the hood), any combination of text values is acceptable.
+
+    Possible values:
+    1 - close problem;
+    2 - acknowledge event;
+    4 - add message;
+    8 - change severity.
+
+    .PARAMETER Message
+
+    Text of the message.
+    Required, if action contains 'add message' flag.
+
+    .PARAMETER Severity
+
+    New severity for events.
+    Required, if action contains 'change severity' flag.
+
+    Possible values:
+    0 - notclassified;
+    1 - information;
+    2 - warning;
+    3 - average;
+    4 - high;
+    5 - disaster.
+
+    .INPUTS
+
+    None, does not support pipeline.
+
+    .OUTPUTS
+
+    PSObject.
+
+
+    .EXAMPLE
+
+    Acknowledges a event.
+
+    Confirm-ZBXEvent TBD
+
+    .LINK
+
+    https://www.zabbix.com/documentation/4.2/manual/api/reference/event/get
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByCredential')]
+    param
+    (
+        [Parameter(Mandatory,
+            ParameterSetName = 'ByCredential')]
+        [uri]
+        $Uri,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $Credential,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [string]
+        $Proxy,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $ProxyCredential,
+
+        [Parameter(Mandatory,
+            ParameterSetName = 'BySession')]
+        [object]
+        $Session,
+
+        [Parameter(Mandatory)]
+        [Alias('eventids')]
+        [string[]]
+        $EventId,
+
+        [Parameter(Mandatory)]
+        [Alias('action')]
+        [ValidateSet('CloseProblem','Acknowledge','AddMessage','ChangeSeverity')]
+        [string[]]
+        $Action,
+
+        [Parameter()]
+        [Alias('message')]
+        [string]
+        $Message,
+
+        [Parameter()]
+        [Alias('severity')]
+        [ValidateSet('NotClassified','Information','Warning','Average','High','Disaster')]
+        [string]
+        $Severity
+    )
+
+    begin
+    {
+        if ($PSCmdlet.ParameterSetName -eq 'BySession')
+        {
+            $currentSession = $Session | Get-ZBXSession -ErrorAction 'Stop' | Select-Object -First 1
+            if ($currentSession)
+            {
+                $Uri = $currentSession.Uri
+                $Credential = $currentSession.Credential
+                $Proxy = $currentSession.Proxy
+                $ProxyCredential = $currentSession.ProxyCredential
+                $ApiVersion = $currentSession.ApiVersion
+            }
+        }
+        $ActionValues = @{
+            'CloseProblem'   = 1
+            'Acknowledge'    = 2
+            'AddMessage'     = 4
+            'ChangeSeverity' = 8
+        }
+        $SeverityValues = @{
+            'NotClassified' = 0
+            'Information'   = 1
+            'Warning'       = 2
+            'Average'       = 3
+            'High'          = 4
+            'Disaster'      = 5
+        }
+        $SessionParameters = @('Uri','Credential','Proxy','ProxyCredential','Session')
+        $CommonParameters = $(([System.Management.Automation.PSCmdlet]::CommonParameters,[System.Management.Automation.PSCmdlet]::OptionalCommonParameters) | ForEach-Object {$PSItem})
+    }
+
+    process
+    {
+
+        $params  = @{}
+
+        #Dynamically adds any bound parameters that are used for the conditions
+        foreach ($Parameter in $PSBoundParameters.GetEnumerator()) {
+            if ($Parameter.key -notin $SessionParameters -and $Parameter.key -notin $CommonParameters) {
+                #uses the hardcoded Alias of the parameter as the API friendly param
+                $apiParam = $MyInvocation.MyCommand.Parameters[$Parameter.key].Aliases[0]
+                switch ($apiParam) {
+                    'action'   { foreach ($value in $parameter.Value) {
+                                    $apiValue += $ActionValues[$value]
+                                 }
+                                 break
+                               }
+                    'severity' { $apiValue = $SeverityValues[$Parameter.Value]; break }
+                    default    { $apiValue = $Parameter.Value }
+                }
+
+                $params[$apiParam] = $apiValue
+
+            }
+        }
+
+        $body = New-ZBXRestBody -Method 'event.acknowledge' -API $ApiVersion -Params $params
+
+
+        $invokeZabbixRestMethodSplat = @{
+            Body        = $body
+            Uri         = $Uri
+            Credential  = $Credential
+            ApiVersion  = $ApiVersion
+            ErrorAction = 'Stop'
+        }
+        if ($Proxy)
+        {
+            $invokeZabbixRestMethodSplat.Proxy = $Proxy
+            if ($ProxyCredential)
+            {
+                $invokeZabbixRestMethodSplat.ProxyCredential = $ProxyCredential
+            }
+        }
+        Invoke-ZBXRestMethod @invokeZabbixRestMethodSplat
+    }
+
+}

--- a/ZabbixPS/Public/Get-ZBXEvent.ps1
+++ b/ZabbixPS/Public/Get-ZBXEvent.ps1
@@ -132,6 +132,7 @@
                 select_acknowledges   = 'extend'
                 selectTags            = 'extend'
                 selectSuppressionData = 'extend'
+                selectHosts           = 'extend'
             }
         }
         if ($EventId)

--- a/ZabbixPS/Public/Get-ZBXProblem.ps1
+++ b/ZabbixPS/Public/Get-ZBXProblem.ps1
@@ -121,7 +121,19 @@ function Get-ZBXProblem
         [Parameter()]
         [Alias('applicationids')]
         [string[]]
-        $ApplicationId
+        $ApplicationId,
+
+        [Parameter()]
+        [Alias('acknowledged')]
+        [ValidateSet('true','false')]
+        [string]
+        $AcknowledgedProblem,
+
+        [Parameter()]
+        [Alias('suppressed')]
+        [ValidateSet('true','false')]
+        [string]
+        $SuppressedProblem
     )
 
     begin
@@ -157,7 +169,11 @@ function Get-ZBXProblem
             if ($Parameter.key -notin $SessionParameters -and $Parameter.key -notin $CommonParameters) {
                 #uses the hardcoded Alias of the parameter as the API friendly param
                 $apiParam = $MyInvocation.MyCommand.Parameters[$Parameter.key].Aliases[0]
-                $params[$apiParam] = $Parameter.Value
+                if ($Parameter.Value -in @('true','false')) {
+                    $params[$apiParam] = [system.convert]::ToBoolean($Parameter.Value)
+                } else {
+                    $params[$apiParam] = $Parameter.Value
+                }
             }
         }
 

--- a/ZabbixPS/Public/Get-ZBXProblem.ps1
+++ b/ZabbixPS/Public/Get-ZBXProblem.ps1
@@ -1,0 +1,185 @@
+function Get-ZBXProblem
+{
+    <#
+    .SYNOPSIS
+
+    Returns a Zabbix Problem.
+
+    .DESCRIPTION
+
+    Returns a Zabbix Problem.
+
+    .PARAMETER Uri
+
+    The Zabbix instance uri.
+
+    .PARAMETER Credential
+
+    Specifies a user account that has permission to the project.
+
+    .PARAMETER Proxy
+
+    Use a proxy server for the request, rather than connecting directly to the Internet resource. Enter the URI of a network proxy server.
+
+    .PARAMETER ProxyCredential
+
+    Specifie a user account that has permission to use the proxy server that is specified by the -Proxy parameter. The default is the current user.
+
+    .PARAMETER Session
+
+    ZabbixPS session, created by New-ZBXSession.
+
+    .PARAMETER EventId
+
+    Return only problems with the given IDs.
+
+    .PARAMETER GroupId
+
+    Return only problems that use the given host groups in problems conditions.
+
+    .PARAMETER HostId
+
+    Return only problems that use the given hosts in problems conditions.
+
+    .PARAMETER ObjectId
+
+    Return only problems that have the given ObjectId in problems conditions.
+
+    .PARAMETER ApplicationId
+
+    Return only problems that have the given ApplicationId in problems conditions.
+
+    .INPUTS
+
+    None, does not support pipeline.
+
+    .OUTPUTS
+
+    PSObject. Zabbix problems.
+
+    .EXAMPLE
+
+    Returns all Zabbix Problems.
+
+    Get-ZBXProblem
+
+    .EXAMPLE
+
+    Returns Zabbix Problem from the HostID 10084.
+
+    Get-ZBXProblem -Session $Session -HostId 10084
+
+    .LINK
+
+    https://www.zabbix.com/documentation/4.2/manual/api/reference/event/get
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByCredential')]
+    param
+    (
+        [Parameter(Mandatory,
+            ParameterSetName = 'ByCredential')]
+        [uri]
+        $Uri,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $Credential,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [string]
+        $Proxy,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $ProxyCredential,
+
+        [Parameter(Mandatory,
+            ParameterSetName = 'BySession')]
+        [object]
+        $Session,
+
+        [Parameter()]
+        [Alias('eventids')]
+        [string[]]
+        $EventId,
+
+        [Parameter()]
+        [Alias('groupids')]
+        [string[]]
+        $GroupId,
+
+        [Parameter()]
+        [Alias('hostids')]
+        [string[]]
+        $HostId,
+
+        [Parameter()]
+        [Alias('objectids')]
+        [string[]]
+        $ObjectId,
+
+        [Parameter()]
+        [Alias('applicationids')]
+        [string[]]
+        $ApplicationId
+    )
+
+    begin
+    {
+        if ($PSCmdlet.ParameterSetName -eq 'BySession')
+        {
+            $currentSession = $Session | Get-ZBXSession -ErrorAction 'Stop' | Select-Object -First 1
+            if ($currentSession)
+            {
+                $Uri = $currentSession.Uri
+                $Credential = $currentSession.Credential
+                $Proxy = $currentSession.Proxy
+                $ProxyCredential = $currentSession.ProxyCredential
+                $ApiVersion = $currentSession.ApiVersion
+            }
+        }
+
+        $SessionParameters = @('Uri','Credential','Proxy','ProxyCredential','Session')
+        $CommonParameters = $(([System.Management.Automation.PSCmdlet]::CommonParameters,[System.Management.Automation.PSCmdlet]::OptionalCommonParameters) | ForEach-Object {$PSItem})
+    }
+
+    process
+    {
+
+        $params  = @{
+            output                = 'extend'
+            select_acknowledges   = 'extend'
+            selectTags            = 'extend'
+        }
+
+        #Dynamically adds any bound parameters that are used for the conditions
+        foreach ($Parameter in $PSBoundParameters.GetEnumerator()){
+            if ($Parameter.key -notin $SessionParameters -and $Parameter.key -notin $CommonParameters) {
+                #uses the hardcoded Alias of the parameter as the API friendly param
+                $apiParam = $MyInvocation.MyCommand.Parameters[$Parameter.key].Aliases[0]
+                $params[$apiParam] = $Parameter.Value
+            }
+        }
+
+        $body = New-ZBXRestBody -Method 'problem.get' -API $ApiVersion -Params $params
+
+
+        $invokeZabbixRestMethodSplat = @{
+            Body        = $body
+            Uri         = $Uri
+            Credential  = $Credential
+            ApiVersion  = $ApiVersion
+            ErrorAction = 'Stop'
+        }
+        if ($Proxy)
+        {
+            $invokeZabbixRestMethodSplat.Proxy = $Proxy
+            if ($ProxyCredential)
+            {
+                $invokeZabbixRestMethodSplat.ProxyCredential = $ProxyCredential
+            }
+        }
+        Invoke-ZBXRestMethod @invokeZabbixRestMethodSplat
+    }
+
+}

--- a/ZabbixPS/Public/Get-ZBXTemplate.ps1
+++ b/ZabbixPS/Public/Get-ZBXTemplate.ps1
@@ -1,0 +1,185 @@
+function Get-ZBXTemplate
+{
+    <#
+    .SYNOPSIS
+
+    Returns a Zabbix Template.
+
+    .DESCRIPTION
+
+    Returns a Zabbix Template.
+
+    .PARAMETER Uri
+
+    The Zabbix instance uri.
+
+    .PARAMETER Credential
+
+    Specifies a user account that has permission to the project.
+
+    .PARAMETER Proxy
+
+    Use a proxy server for the request, rather than connecting directly to the Internet resource. Enter the URI of a network proxy server.
+
+    .PARAMETER ProxyCredential
+
+    Specifie a user account that has permission to use the proxy server that is specified by the -Proxy parameter. The default is the current user.
+
+    .PARAMETER Session
+
+    ZabbixPS session, created by New-ZBXSession.
+
+    .PARAMETER TemplateId
+
+    Return only Templates with the given IDs.
+
+    .PARAMETER GroupId
+
+    Return only Templates that use the given host groups in the search conditions.
+
+    .PARAMETER HostId
+
+    Return only Templates that use the given hosts in the search conditions.
+
+    .PARAMETER ParentTemplateId
+
+    Return the children Templates of the Parent Templates that is given in the search conditions.
+
+    .PARAMETER TreiggerId
+
+    Return only Templates that have the given ApplicationId in Templates conditions.
+
+    .INPUTS
+
+    None, does not support pipeline.
+
+    .OUTPUTS
+
+    PSObject. Zabbix Templates.
+
+    .EXAMPLE
+
+    Returns all Zabbix Templates.
+
+    Get-ZBXTemplate
+
+    .EXAMPLE
+
+    Returns Zabbix Template from the HostID 10084.
+
+    Get-ZBXTemplate -Session $Session -HostId 10084
+
+    .LINK
+
+    https://www.zabbix.com/documentation/4.2/manual/api/reference/event/get
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByCredential')]
+    param
+    (
+        [Parameter(Mandatory,
+            ParameterSetName = 'ByCredential')]
+        [uri]
+        $Uri,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $Credential,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [string]
+        $Proxy,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $ProxyCredential,
+
+        [Parameter(Mandatory,
+            ParameterSetName = 'BySession')]
+        [object]
+        $Session,
+
+        [Parameter()]
+        [Alias('templateids')]
+        [string[]]
+        $TemplateId,
+
+        [Parameter()]
+        [Alias('groupids')]
+        [string[]]
+        $GroupId,
+
+        [Parameter()]
+        [Alias('hostids')]
+        [string[]]
+        $HostId,
+
+        [Parameter()]
+        [Alias('parentTemplateids')]
+        [string[]]
+        $ParentTemplateId,
+
+        [Parameter()]
+        [Alias('triggerids')]
+        [string[]]
+        $TriggerId
+    )
+
+    begin
+    {
+        if ($PSCmdlet.ParameterSetName -eq 'BySession')
+        {
+            $currentSession = $Session | Get-ZBXSession -ErrorAction 'Stop' | Select-Object -First 1
+            if ($currentSession)
+            {
+                $Uri = $currentSession.Uri
+                $Credential = $currentSession.Credential
+                $Proxy = $currentSession.Proxy
+                $ProxyCredential = $currentSession.ProxyCredential
+                $ApiVersion = $currentSession.ApiVersion
+            }
+        }
+
+        $SessionParameters = @('Uri','Credential','Proxy','ProxyCredential','Session')
+        $CommonParameters = $(([System.Management.Automation.PSCmdlet]::CommonParameters,[System.Management.Automation.PSCmdlet]::OptionalCommonParameters) | ForEach-Object {$PSItem})
+    }
+
+    process
+    {
+
+        $params  = @{
+            output                = 'extend'
+            selectTags            = 'extend'
+            selectGroups          = 'extend'
+        }
+
+        #Dynamically adds any bound parameters that are used for the conditions
+        foreach ($Parameter in $PSBoundParameters.GetEnumerator()){
+            if ($Parameter.key -notin $SessionParameters -and $Parameter.key -notin $CommonParameters) {
+                #uses the hardcoded Alias of the parameter as the API friendly param
+                $apiParam = $MyInvocation.MyCommand.Parameters[$Parameter.key].Aliases[0]
+                $params[$apiParam] = $Parameter.Value
+            }
+        }
+
+        $body = New-ZBXRestBody -Method 'template.get' -API $ApiVersion -Params $params
+
+
+        $invokeZabbixRestMethodSplat = @{
+            Body        = $body
+            Uri         = $Uri
+            Credential  = $Credential
+            ApiVersion  = $ApiVersion
+            ErrorAction = 'Stop'
+        }
+        if ($Proxy)
+        {
+            $invokeZabbixRestMethodSplat.Proxy = $Proxy
+            if ($ProxyCredential)
+            {
+                $invokeZabbixRestMethodSplat.ProxyCredential = $ProxyCredential
+            }
+        }
+        Invoke-ZBXRestMethod @invokeZabbixRestMethodSplat
+    }
+
+}

--- a/ZabbixPS/Public/Get-ZBXTrigger.ps1
+++ b/ZabbixPS/Public/Get-ZBXTrigger.ps1
@@ -1,0 +1,184 @@
+function Get-ZBXTrigger
+{
+    <#
+    .SYNOPSIS
+
+    Returns a Zabbix Trigger.
+
+    .DESCRIPTION
+
+    Returns a Zabbix Trigger.
+
+    .PARAMETER Uri
+
+    The Zabbix instance uri.
+
+    .PARAMETER Credential
+
+    Specifies a user account that has permission to the project.
+
+    .PARAMETER Proxy
+
+    Use a proxy server for the request, rather than connecting directly to the Internet resource. Enter the URI of a network proxy server.
+
+    .PARAMETER ProxyCredential
+
+    Specifie a user account that has permission to use the proxy server that is specified by the -Proxy parameter. The default is the current user.
+
+    .PARAMETER Session
+
+    ZabbixPS session, created by New-ZBXSession.
+
+    .PARAMETER TriggerId
+
+    Return only Triggers with the given IDs.
+
+    .PARAMETER GroupId
+
+    Return only Triggers that use the given host groups.
+
+    .PARAMETER HostId
+
+    Return only Triggers that use the given hosts.
+
+    .PARAMETER TemplateId
+
+    Return only Triggers that belong to given templates.
+
+    .PARAMETER ApplicationId
+
+    Return only triggers that contain items from the given applications.
+
+    .INPUTS
+
+    None, does not support pipeline.
+
+    .OUTPUTS
+
+    PSObject. Zabbix Triggers.
+
+    .EXAMPLE
+
+    Returns all Zabbix Triggers.
+
+    Get-ZBXTrigger
+
+    .EXAMPLE
+
+    Returns Zabbix Trigger from the HostID 10084.
+
+    Get-ZBXTrigger -Session $Session -HostId 10084
+
+    .LINK
+
+    https://www.zabbix.com/documentation/4.2/manual/api/reference/event/get
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByCredential')]
+    param
+    (
+        [Parameter(Mandatory,
+            ParameterSetName = 'ByCredential')]
+        [uri]
+        $Uri,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $Credential,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [string]
+        $Proxy,
+
+        [Parameter(ParameterSetName = 'ByCredential')]
+        [pscredential]
+        $ProxyCredential,
+
+        [Parameter(Mandatory,
+            ParameterSetName = 'BySession')]
+        [object]
+        $Session,
+
+        [Parameter()]
+        [Alias('triggerids')]
+        [string[]]
+        $TriggerId,
+
+        [Parameter()]
+        [Alias('groupids')]
+        [string[]]
+        $GroupId,
+
+        [Parameter()]
+        [Alias('hostids')]
+        [string[]]
+        $HostId,
+
+        [Parameter()]
+        [Alias('templateids')]
+        [string[]]
+        $TemplateId,
+
+        [Parameter()]
+        [Alias('applicationids')]
+        [string[]]
+        $ApplicationId
+    )
+
+    begin
+    {
+        if ($PSCmdlet.ParameterSetName -eq 'BySession')
+        {
+            $currentSession = $Session | Get-ZBXSession -ErrorAction 'Stop' | Select-Object -First 1
+            if ($currentSession)
+            {
+                $Uri = $currentSession.Uri
+                $Credential = $currentSession.Credential
+                $Proxy = $currentSession.Proxy
+                $ProxyCredential = $currentSession.ProxyCredential
+                $ApiVersion = $currentSession.ApiVersion
+            }
+        }
+
+        $SessionParameters = @('Uri','Credential','Proxy','ProxyCredential','Session')
+        $CommonParameters = $(([System.Management.Automation.PSCmdlet]::CommonParameters,[System.Management.Automation.PSCmdlet]::OptionalCommonParameters) | ForEach-Object {$PSItem})
+    }
+
+    process
+    {
+
+        $params  = @{
+            output                = 'extend'
+            selectTags            = 'extend'
+        }
+
+        #Dynamically adds any bound parameters that are used for the conditions
+        foreach ($Parameter in $PSBoundParameters.GetEnumerator()){
+            if ($Parameter.key -notin $SessionParameters -and $Parameter.key -notin $CommonParameters) {
+                #uses the hardcoded Alias of the parameter as the API friendly param
+                $apiParam = $MyInvocation.MyCommand.Parameters[$Parameter.key].Aliases[0]
+                $params[$apiParam] = $Parameter.Value
+            }
+        }
+
+        $body = New-ZBXRestBody -Method 'trigger.get' -API $ApiVersion -Params $params
+
+
+        $invokeZabbixRestMethodSplat = @{
+            Body        = $body
+            Uri         = $Uri
+            Credential  = $Credential
+            ApiVersion  = $ApiVersion
+            ErrorAction = 'Stop'
+        }
+        if ($Proxy)
+        {
+            $invokeZabbixRestMethodSplat.Proxy = $Proxy
+            if ($ProxyCredential)
+            {
+                $invokeZabbixRestMethodSplat.ProxyCredential = $ProxyCredential
+            }
+        }
+        Invoke-ZBXRestMethod @invokeZabbixRestMethodSplat
+    }
+
+}

--- a/ZabbixPS/ZabbixPS.psd1
+++ b/ZabbixPS/ZabbixPS.psd1
@@ -69,7 +69,7 @@ Description = 'Functions for interacting with Zabbix'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Format-ZBXTags', 'Get-ZBXAction', 'Get-ZBXAlert', 'Get-ZBXApplication',
+FunctionsToExport = 'Confirm-ZBXEvent','Format-ZBXTags', 'Get-ZBXAction', 'Get-ZBXAlert', 'Get-ZBXApplication',
                'Get-ZBXEvent', 'Get-ZBXGraph', 'Get-ZBXHistory', 'Get-ZBXHost',
                'Get-ZBXHostGroup', 'Get-ZBXMaintenance', 'Get-ZBXProblem', 'Get-ZBXSession', 'Get-ZBXTemplate', 'Get-ZBXTrigger',
                'Initialize-ZBXSession', 'Invoke-ZBXRestMethod', 'New-ZBXMaintenance',

--- a/ZabbixPS/ZabbixPS.psd1
+++ b/ZabbixPS/ZabbixPS.psd1
@@ -69,11 +69,11 @@ Description = 'Functions for interacting with Zabbix'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Format-ZBXTags', 'Get-ZBXAction', 'Get-ZBXAlert', 'Get-ZBXApplication', 
-               'Get-ZBXEvent', 'Get-ZBXGraph', 'Get-ZBXHistory', 'Get-ZBXHost', 
-               'Get-ZBXHostGroup', 'Get-ZBXMaintenance', 'Get-ZBXSession', 
-               'Initialize-ZBXSession', 'Invoke-ZBXRestMethod', 'New-ZBXMaintenance', 
-               'New-ZBXSession', 'Remove-ZBXAction', 'Remove-ZBXMaintenance', 
+FunctionsToExport = 'Format-ZBXTags', 'Get-ZBXAction', 'Get-ZBXAlert', 'Get-ZBXApplication',
+               'Get-ZBXEvent', 'Get-ZBXGraph', 'Get-ZBXHistory', 'Get-ZBXHost',
+               'Get-ZBXHostGroup', 'Get-ZBXMaintenance', 'Get-ZBXProblem', 'Get-ZBXSession',
+               'Initialize-ZBXSession', 'Invoke-ZBXRestMethod', 'New-ZBXMaintenance',
+               'New-ZBXSession', 'Remove-ZBXAction', 'Remove-ZBXMaintenance',
                'Remove-ZBXSession', 'Save-ZBXSession'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/ZabbixPS/ZabbixPS.psd1
+++ b/ZabbixPS/ZabbixPS.psd1
@@ -71,7 +71,7 @@ Description = 'Functions for interacting with Zabbix'
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = 'Format-ZBXTags', 'Get-ZBXAction', 'Get-ZBXAlert', 'Get-ZBXApplication',
                'Get-ZBXEvent', 'Get-ZBXGraph', 'Get-ZBXHistory', 'Get-ZBXHost',
-               'Get-ZBXHostGroup', 'Get-ZBXMaintenance', 'Get-ZBXProblem', 'Get-ZBXSession',
+               'Get-ZBXHostGroup', 'Get-ZBXMaintenance', 'Get-ZBXProblem', 'Get-ZBXSession', 'Get-ZBXTemplate', 'Get-ZBXTrigger',
                'Initialize-ZBXSession', 'Invoke-ZBXRestMethod', 'New-ZBXMaintenance',
                'New-ZBXSession', 'Remove-ZBXAction', 'Remove-ZBXMaintenance',
                'Remove-ZBXSession', 'Save-ZBXSession'


### PR DESCRIPTION
I wanted the ability to Acknowledge Events, but then I realized there wasn't a way to see Problems, and then I realized it might be handy to dynamically create the Body of the API call. 

Then I started messing with Templates and Triggers.

So Here is a brief summary of what I am proposing..
New internal command that creates the API body based on parameter input (`New-ZBXRestBody`). This function is not exported on purpose.
Any of the case sensitive API params are put into an `[Alias()]` of the parameter so it can be called programmatically without violating the PowerShell best practices for naming parameters. 
Only add if/else/switch statements when API param values need to be cast a specific way (`bool`)
Include as much information in the API return so that users may filter what they want at the Powershell pipeline (maybe need a way of filtering the API call more/less output in the future). 
Don't use the `return` keyword or unnecessary script blocks `end {}` 

I only included these changes on new cmdlets I have written as examples (except for Get-ZBXEvent where I needed some more info on which host an Event fired on), but these changes could be added to the existing ones as well, and could allow for quicker creation of additional cmdlets as one is only adding parameters (with alias), and maybe a few internal logic changes.

Let me know what you think of these changes. 